### PR TITLE
Add the notebook for creating icl examples

### DIFF
--- a/gpt-4/create_hallucination_icl.ipynb
+++ b/gpt-4/create_hallucination_icl.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2906c69a-68f0-4b15-9a45-e34e7ca1f49b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from run_hallucination_detection import *\n",
+    "demonstrations = read_jsonl(DATASET_PATHS[\"valid_mimic\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f218439-db46-46ae-a305-561dabcaea06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "icl_examples = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6acb5cd5-a60e-43dd-a091-3d334e17ad26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "def remove_class_label(text):\n",
+    "    return re.sub(r' class=\"[^\"]*\"', '', text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdd435ab-dfc7-4482-8ee3-9b9473004415",
+   "metadata": {},
+   "source": [
+    "## V1 Format of the prompts "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26378110-7128-4208-9acd-c4fcda89d953",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ex = demonstrations[0]\n",
+    "print(create_icl_example_v1(ex, add_hallucination_type=True))\n",
+    "\n",
+    "cot_description = \"\"\"\n",
+    "- \"Your <error class=\"word_unsupported\">red blood cell count</error> was followed and was stable.\" The BHC does not state that the red blood cell count was followed. Instead the hematocrit remained stable according to the BHC.\n",
+    "- \"You were treated with <error class=\"time_unsupported\">2 days</error> of antibiotics which were stopped prior to discharge.\" There is no clear time interval for antibiotic treatment in the BHC.\n",
+    "\"\"\"\n",
+    "\n",
+    "cot_no_label = remove_class_label(cot_description)\n",
+    "ex['cot_description'] = cot_no_label.strip()\n",
+    "ex['cot_description_with_label'] = cot_description.strip()\n",
+    "\n",
+    "print(cot_no_label)\n",
+    "icl_examples.append(ex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94fdd3fe-ceff-4240-a0da-d1e20a5d4dc8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ex = demonstrations[1]\n",
+    "print(create_icl_example_v1(ex, add_hallucination_type=True))\n",
+    "\n",
+    "cot_description = \"\"\"\n",
+    "- \"You were also given <error class=\"medication_unsupported\">blood</error> because you lost a fair amount in your stool.\" The BHC does not state that the patient received blood.\n",
+    "- \"Please hold off from taking your Isosorbide mononitrate (Imdur) and losartan until you meet with your primary care physician within <error class=\"time_unsupported\">the week</error>.\" The BHC includes the information that the patient should meet with his primary care physician within one week (\"1 week\") which is different to within the week, which only includes the remainder of the current week.\n",
+    "- \"Also, hold from taking your torsemide <error class=\"contradicted_fact\">(unless you notice significant weight gain in the next few days)</error> until you meet with your primary care physician within <error class=\"time_unsupported\">the week</error>\" There are no specific instructions in the BHC stating the the patient should start the Torsemid by himself; and the BHC includes the information that the patient should meet with his primary care physician within one week (\"1 week\") which is different to within the week, which only includes the remainder of the current week.\n",
+    "\"\"\"\n",
+    "cot_no_label = remove_class_label(cot_description)\n",
+    "ex['cot_description'] = cot_no_label.strip()\n",
+    "ex['cot_description_with_label'] = cot_description.strip()\n",
+    "\n",
+    "print(cot_no_label)\n",
+    "icl_examples.append(ex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74996cb5-a186-4609-8d26-0c8a7b041778",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ex = demonstrations[2]\n",
+    "print(create_icl_example_v1(ex, add_hallucination_type=True))\n",
+    "\n",
+    "cot_description = \"\"\"\n",
+    "No errors detected in the AVS based on the provided BHC.\n",
+    "\"\"\"\n",
+    "\n",
+    "cot_no_label = remove_class_label(cot_description)\n",
+    "ex['cot_description'] = cot_no_label.strip()\n",
+    "ex['cot_description_with_label'] = cot_description.strip()\n",
+    "\n",
+    "print(cot_no_label)\n",
+    "icl_examples.append(ex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c305c928-d21c-4883-8cce-b6b8906e1448",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ex = demonstrations[3]\n",
+    "print(create_icl_example_v1(ex, add_hallucination_type=True))\n",
+    "\n",
+    "cot_description = \"\"\"\n",
+    "- \"We monitored you in the ___ and <error class=\"location_unsupported\">on the medical floors</error>.\" There is no information in the BHC that the patient was monitored on the medical floors. The patient could have been monitored somewhere else in the hospital.\n",
+    "- \"You remained stable and you <error class=\"contradicted_fact\">received Valium</error> as needed for withdrawl symptoms.\" The BHC states that the patient did not require Valium.\n",
+    "- \"These can be done as an outpatient and we have <error class=\"word_unsupported\">placed orders in the computer</error> for you to have them done.\" Unclear whether the orders for an MRI and EEG were already placed in the computer.\n",
+    "- \"They also recommended seeing a <error class=\"name_unsupported\">neurologist</error> as an outpatient and your primary care provider <error class=\"word_unsupported\">is aware</error> and ___ help set up the tests and appointment with <error class=\"name_unsupported\">neurology</error>.\" The neurologist in the hospital recommend doing an MRI of the head and an EEG as an outpatient, which is already stated in the Discharge Instructions. However, they do not specifically recommend seeing a neurologist as an outpatient; The BHC does not state that the primary care provider is aware of the recommendations.\n",
+    "\"\"\"\n",
+    "\n",
+    "cot_no_label = remove_class_label(cot_description)\n",
+    "ex['cot_description'] = cot_no_label.strip()\n",
+    "ex['cot_description_with_label'] = cot_description.strip()\n",
+    "\n",
+    "print(cot_no_label)\n",
+    "icl_examples.append(ex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c63a7a30-adf9-4ca8-8f90-2ca047bfb9ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ex = demonstrations[4]\n",
+    "print(create_icl_example_v1(ex, add_hallucination_type=True))\n",
+    "\n",
+    "cot_description = \"\"\"\n",
+    "- \"You can <error class=\"medication_unsupported\">take an anti-nausea medicine called zofran as needed</error>.\" The patient received Zofran in the hospital, but Zofran is not presribed as needed for own use.\n",
+    "- \"You were seen ___ the hospital by the nutritionist, who recommended that you take a nutritional supplement <error class=\"time_unsupported\">with each meal</error>, such as Boost or Carnation.\" Nutrional supplements are recommended three times a day, but it is not stated that they should be taken with each meal.\n",
+    "\"\"\"\n",
+    "\n",
+    "cot_no_label = remove_class_label(cot_description)\n",
+    "ex['cot_description'] = cot_no_label.strip()\n",
+    "ex['cot_description_with_label'] = cot_description.strip()\n",
+    "\n",
+    "print(cot_no_label)\n",
+    "icl_examples.append(ex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "910a8f71-c928-4359-8e16-6f6ac6cfd90e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "write_jsonl(\"hallucination_detection_data/icl_v1.jsonl\", icl_examples)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
In this PR, it contains a jupyter notebook for `cot_description` and `cot_description_no_labels` that are used for creating the icl examples for generating the final results in the paper. You have to rerun the notebooks yourself and show the results (as we cannot share the MIMIC data directly). It assumes you've already had the data directory set up. 

After generating the data in `hallucination_detection_data/icl_v1.jsonl`, here are the commands for running the generation and obtaining the final results. 
```bash
# Run hallucination detection 
python run_hallucination_detection.py --task_name test_mimic --prompt_id 3 --icl_version 1 --model_name gpt-4 --n_shot 5 --verbose 
python run_hallucination_detection.py --task_name test_mimic --prompt_id 3 --icl_version 1 --model_name gpt-4 --n_shot 5 --verbose --add_label
python run_hallucination_detection.py --task_name test_mimic --prompt_id 3 --icl_version 1 --model_name gpt-4 --n_shot 5 --verbose --no_cot 
python run_hallucination_detection.py --task_name test_mimic --prompt_id 3 --icl_version 1 --model_name gpt-4 --n_shot 5 --verbose --no_cot --add_label

python run_hallucination_detection.py --task_name test_generated --prompt_id 3 --icl_version 1 --model_name gpt-4 --n_shot 5 --verbose --no_cot 
python run_hallucination_detection.py --task_name test_generated --prompt_id 3 --icl_version 1 --model_name gpt-4 --n_shot 5 --verbose --no_cot --add_label
```